### PR TITLE
Removed unwanted prints for ping-pong frames

### DIFF
--- a/include/websocket_handler.h
+++ b/include/websocket_handler.h
@@ -36,11 +36,11 @@
 
 typedef enum websocket_op {
 	websocket_op_continue_payload = 0,
-	websocket_op_utf_8_text,
-	websocket_op_binary_data,
+	websocket_op_utf_8_text = 1,
+	websocket_op_binary_data = 2,
 	websocket_op_termination_frame = 8,
-	websocket_op_ping_frame,
-	websocket_op_pong_frame,
+	websocket_op_ping_frame = 9,
+	websocket_op_pong_frame = 10,
 }websocket_op_t;
 
 void websocket_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data);

--- a/include/websocket_handler.h
+++ b/include/websocket_handler.h
@@ -17,6 +17,32 @@
 
 #define WEBSOCKET_HOST_URI CONFIG_SERVER_WEBSOCKET_URI
 
+/*
+ * 0x00: this frame continues the payload from the last.
+ * 0x01: this frame includes utf-8 text data.
+ * 0x02: this frame includes binary data.
+ * 0x08: this frame terminates the connection.
+ * 0x09: this frame is a ping.
+ * 0x0a: this frame is a pong.
+ *
+ * A ping or pong is just a regular frame, but it's a control frame.
+ * Pings have an opcode of 0x9, and pongs have an opcode of 0xA.
+ * When you get a ping, send back a pong with the exact same Payload Data
+ * as the ping (for pings and pongs, the max payload length is 125).
+ * You might also get a pong without ever sending a ping; ignore this if it happens.
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers
+ */
+
+typedef enum websocket_op {
+	websocket_op_continue_payload = 0,
+	websocket_op_utf_8_text,
+	websocket_op_binary_data,
+	websocket_op_termination_frame = 8,
+	websocket_op_ping_frame,
+	websocket_op_pong_frame,
+}websocket_op_t;
+
 void websocket_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data);
 esp_websocket_client_handle_t websocket_network_manager();
 int websocket_send_data(esp_websocket_client_handle_t network_handle, char* payload);

--- a/websocket_handler.c
+++ b/websocket_handler.c
@@ -24,6 +24,7 @@ void websocket_event_handler(void *handler_args, esp_event_base_t base, int32_t 
             break;
 
         case WEBSOCKET_EVENT_DATA:
+        	//Avoid printing logs if it is just a ping/pong frame.
         	if(websocket_op_ping_frame != data->op_code && websocket_op_pong_frame != data->op_code)
         	{
         		ESP_LOGI(TAG, "WEBSOCKET_EVENT_DATA");

--- a/websocket_handler.c
+++ b/websocket_handler.c
@@ -24,9 +24,12 @@ void websocket_event_handler(void *handler_args, esp_event_base_t base, int32_t 
             break;
 
         case WEBSOCKET_EVENT_DATA:
-            ESP_LOGI(TAG, "WEBSOCKET_EVENT_DATA");
-            ESP_LOGI(TAG, "Received opcode=%d", data->op_code);
-            ESP_LOGW(TAG, "Received=%.*s\r\n", data->data_len, (char*)data->data_ptr);
+        	if(websocket_op_ping_frame != data->op_code && websocket_op_pong_frame != data->op_code)
+        	{
+        		ESP_LOGI(TAG, "WEBSOCKET_EVENT_DATA");
+        		ESP_LOGI(TAG, "Received opcode=%d", data->op_code);
+        		ESP_LOGW(TAG, "Received=%.*s\r\n", data->data_len, (char*)data->data_ptr);
+        	}
             break;
         case WEBSOCKET_EVENT_ERROR:
             ESP_LOGI(TAG, "WEBSOCKET_EVENT_ERROR");


### PR DESCRIPTION
Added an opcode table for future refs and added a check to see if the opcode is 0x9 or 0xA prints will be ignored since server or host keeps sending pings to each other at a frequency. 