### PR TITLE
Fixed Log disappears if network not connected for websocket and TCP-Client

### DIFF
--- a/include/tcp_handler.h
+++ b/include/tcp_handler.h
@@ -27,12 +27,12 @@ extern "C" {
 
 struct tcp_network_data
 {
-    char rx_buffer[128];
-    char addr_str[128];
-    int addr_family;
-    int ip_protocol;
-    struct sockaddr_in dest_addr;
-    int sock;
+	char rx_buffer[128];
+	char addr_str[128];
+	int addr_family;
+	int ip_protocol;
+	struct sockaddr_in dest_addr;
+	int sock;
 };
 
 bool tcp_network_manager(struct tcp_network_data* nm);

--- a/include/tcp_handler.h
+++ b/include/tcp_handler.h
@@ -18,6 +18,10 @@
 #include "lwip/sys.h"
 #include <lwip/netdb.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define TCP_HOST_IP_ADDR CONFIG_SERVER_IP_ADDRESS
 #define TCP_PORT CONFIG_SERVER_PORT
 
@@ -35,5 +39,9 @@ bool tcp_network_manager(struct tcp_network_data* nm);
 int tcp_send_data(struct tcp_network_data* nm, char* payload);
 char* tcp_receive_data(struct tcp_network_data* nm);
 void tcp_close_network_manager(struct tcp_network_data* nm);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/tcp_handler.h
+++ b/include/tcp_handler.h
@@ -31,7 +31,7 @@ struct tcp_network_data
     int sock;
 };
 
-void tcp_network_manager(struct tcp_network_data* nm);
+bool tcp_network_manager(struct tcp_network_data* nm);
 int tcp_send_data(struct tcp_network_data* nm, char* payload);
 char* tcp_receive_data(struct tcp_network_data* nm);
 void tcp_close_network_manager(struct tcp_network_data* nm);

--- a/include/udp_handler.h
+++ b/include/udp_handler.h
@@ -18,6 +18,10 @@
 #include "lwip/sys.h"
 #include <lwip/netdb.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define HOST_IP_ADDR CONFIG_SERVER_IP_ADDRESS
 #define PORT CONFIG_SERVER_PORT
 
@@ -35,5 +39,9 @@ void network_manager(struct network_data* nm);
 int send_data(struct network_data* nm, char* payload);
 char* receive_data(struct network_data* nm);
 void close_network_manager(struct network_data* nm);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/udp_handler.h
+++ b/include/udp_handler.h
@@ -27,12 +27,12 @@ extern "C" {
 
 struct network_data
 {
-    char rx_buffer[128];
-    char addr_str[128];
-    int addr_family;
-    int ip_protocol;
-    struct sockaddr_in dest_addr;
-    int sock;
+	char rx_buffer[128];
+	char addr_str[128];
+	int addr_family;
+	int ip_protocol;
+	struct sockaddr_in dest_addr;
+	int sock;
 };
 
 void network_manager(struct network_data* nm);

--- a/include/websocket_handler.h
+++ b/include/websocket_handler.h
@@ -36,11 +36,11 @@
 
 typedef enum websocket_op {
 	websocket_op_continue_payload = 0,
-	websocket_op_utf_8_text,
-	websocket_op_binary_data,
+	websocket_op_utf_8_text = 1,
+	websocket_op_binary_data = 2,
 	websocket_op_termination_frame = 8,
-	websocket_op_ping_frame,
-	websocket_op_pong_frame,
+	websocket_op_ping_frame = 9,
+	websocket_op_pong_frame = 10,
 }websocket_op_t;
 
 void websocket_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data);

--- a/include/websocket_handler.h
+++ b/include/websocket_handler.h
@@ -17,6 +17,32 @@
 
 #define WEBSOCKET_HOST_URI CONFIG_SERVER_WEBSOCKET_URI
 
+/*
+ * 0x00: this frame continues the payload from the last.
+ * 0x01: this frame includes utf-8 text data.
+ * 0x02: this frame includes binary data.
+ * 0x08: this frame terminates the connection.
+ * 0x09: this frame is a ping.
+ * 0x0a: this frame is a pong.
+ *
+ * A ping or pong is just a regular frame, but it's a control frame.
+ * Pings have an opcode of 0x9, and pongs have an opcode of 0xA.
+ * When you get a ping, send back a pong with the exact same Payload Data
+ * as the ping (for pings and pongs, the max payload length is 125).
+ * You might also get a pong without ever sending a ping; ignore this if it happens.
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers
+ */
+
+typedef enum websocket_op {
+	websocket_op_continue_payload = 0,
+	websocket_op_utf_8_text,
+	websocket_op_binary_data,
+	websocket_op_termination_frame = 8,
+	websocket_op_ping_frame,
+	websocket_op_pong_frame,
+}websocket_op_t;
+
 void websocket_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data);
 esp_websocket_client_handle_t websocket_network_manager();
 int websocket_send_data(esp_websocket_client_handle_t network_handle, char* payload);

--- a/include/websocket_handler.h
+++ b/include/websocket_handler.h
@@ -14,6 +14,9 @@
 #include "esp_websocket_client.h"
 #include "esp_event.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define WEBSOCKET_HOST_URI CONFIG_SERVER_WEBSOCKET_URI
 
@@ -47,5 +50,9 @@ void websocket_event_handler(void *handler_args, esp_event_base_t base, int32_t 
 esp_websocket_client_handle_t websocket_network_manager();
 int websocket_send_data(esp_websocket_client_handle_t network_handle, char* payload);
 void websocket_close_network_manager(esp_websocket_client_handle_t network_handle);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/wifi_logger.h
+++ b/include/wifi_logger.h
@@ -27,6 +27,7 @@ void generate_log_message(esp_log_level_t level, const char *TAG, int line, cons
 int system_log_message_route(const char* fmt, va_list tag);
 void start_wifi_logger(void);
 void wifi_logger();
+bool is_connected(void* handle_t);
 
 #endif
 

--- a/include/wifi_logger.h
+++ b/include/wifi_logger.h
@@ -10,6 +10,10 @@
 #include "esp_system.h"
 #include "freertos/queue.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MESSAGE_QUEUE_SIZE CONFIG_MESSAGE_QUEUE_SIZE
 #define BUFFER_SIZE CONFIG_BUFFER_SIZE
 
@@ -28,6 +32,10 @@ int system_log_message_route(const char* fmt, va_list tag);
 void start_wifi_logger(void);
 void wifi_logger();
 bool is_connected(void* handle_t);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/tcp_handler.c
+++ b/tcp_handler.c
@@ -10,36 +10,36 @@ static const char *TAG = "tcp_handler";
  **/
 bool tcp_network_manager(struct tcp_network_data* nm)
 {
-    nm->dest_addr.sin_addr.s_addr = inet_addr(TCP_HOST_IP_ADDR);
-    nm->dest_addr.sin_family = AF_INET;
-    nm->dest_addr.sin_port = htons(TCP_PORT);
-    nm->addr_family = AF_INET;
-    nm->ip_protocol = IPPROTO_IP;
-    inet_ntoa_r(nm->dest_addr.sin_addr, nm->addr_str, sizeof(nm->addr_str) - 1);
+	nm->dest_addr.sin_addr.s_addr = inet_addr(TCP_HOST_IP_ADDR);
+	nm->dest_addr.sin_family = AF_INET;
+	nm->dest_addr.sin_port = htons(TCP_PORT);
+	nm->addr_family = AF_INET;
+	nm->ip_protocol = IPPROTO_IP;
+	inet_ntoa_r(nm->dest_addr.sin_addr, nm->addr_str, sizeof(nm->addr_str) - 1);
 
-    nm->sock = socket(nm->addr_family, SOCK_STREAM, nm->ip_protocol);
-    if (nm->sock < 0)
-    {
-        ESP_LOGE(TAG, "Unable to create socket: errno %d", errno);
-        tcp_close_network_manager(nm);
-        return false;
-    }
-    else
-    {
-        ESP_LOGI(TAG, "Socket created");
-    }
+	nm->sock = socket(nm->addr_family, SOCK_STREAM, nm->ip_protocol);
+	if (nm->sock < 0)
+	{
+		ESP_LOGE(TAG, "Unable to create socket: errno %d", errno);
+		tcp_close_network_manager(nm);
+		return false;
+	}
+	else
+	{
+		ESP_LOGI(TAG, "Socket created");
+	}
 
-    int err = connect(nm->sock, (struct sockaddr *)&nm->dest_addr, sizeof(nm->dest_addr));
-    if (err != 0) {
-        ESP_LOGE(TAG, "Socket unable to connect: errno %d", errno);
-        tcp_close_network_manager(nm);
-        return false;
-    }
-    else
-    {
-        ESP_LOGI(TAG, "Successfully connected to %s:%d with status %d", TCP_HOST_IP_ADDR, TCP_PORT, errno);
-    }
-    return true;
+	int err = connect(nm->sock, (struct sockaddr *)&nm->dest_addr, sizeof(nm->dest_addr));
+	if (err != 0) {
+		ESP_LOGE(TAG, "Socket unable to connect: errno %d", errno);
+		tcp_close_network_manager(nm);
+		return false;
+	}
+	else
+	{
+		ESP_LOGI(TAG, "Successfully connected to %s:%d with status %d", TCP_HOST_IP_ADDR, TCP_PORT, errno);
+	}
+	return true;
 }
 
 /**
@@ -51,24 +51,24 @@ bool tcp_network_manager(struct tcp_network_data* nm)
  **/
 int tcp_send_data(struct tcp_network_data* nm, char* payload)
 {
-    if(nm->sock < 0)
-    {
-        ESP_LOGE(TAG, "%s", "Socket does not exist");
-        return -1;
-    }
-    else
-    {
-        int err = send(nm->sock, payload, strlen(payload), 0);
-        if (err < 0) 
-        {
-            ESP_LOGE(TAG, "Error occurred during sending: errno %d", errno);
-        }
-        else
-        {
-            ESP_LOGD(TAG, "%s", "Message sent");
-        }
-        return err;
-    }
+	if(nm->sock < 0)
+	{
+		ESP_LOGE(TAG, "%s", "Socket does not exist");
+		return -1;
+	}
+	else
+	{
+		int err = send(nm->sock, payload, strlen(payload), 0);
+		if (err < 0)
+		{
+			ESP_LOGE(TAG, "Error occurred during sending: errno %d", errno);
+		}
+		else
+		{
+			ESP_LOGD(TAG, "%s", "Message sent");
+		}
+		return err;
+	}
 }
 
 /**
@@ -79,28 +79,28 @@ int tcp_send_data(struct tcp_network_data* nm, char* payload)
  **/
 char* tcp_receive_data(struct tcp_network_data* nm)
 {
-    if (nm->sock < 0)
-    {
-        ESP_LOGE(TAG, "%s", "Socket doesnot exist");
-        return NULL;
-    }
-    else
-    {
-        int len = recv(nm->sock, nm->rx_buffer, sizeof(nm->rx_buffer) - 1, 0);
+	if (nm->sock < 0)
+	{
+		ESP_LOGE(TAG, "%s", "Socket doesnot exist");
+		return NULL;
+	}
+	else
+	{
+		int len = recv(nm->sock, nm->rx_buffer, sizeof(nm->rx_buffer) - 1, 0);
 
-        if (len < 0) 
-        {
-            ESP_LOGE(TAG, "recvfrom failed: errno %d", errno);
-            return NULL;
-        }
-        else
-        {
-            nm->rx_buffer[len] = 0; // Null-terminate whatever we received and treat like a string
-            ESP_LOGD(TAG, "Received %d bytes from %s:", len, nm->addr_str);
-            ESP_LOGD(TAG, "%s", nm->rx_buffer);
-            return nm->rx_buffer;
-        }
-    }
+		if (len < 0)
+		{
+			ESP_LOGE(TAG, "recvfrom failed: errno %d", errno);
+			return NULL;
+		}
+		else
+		{
+			nm->rx_buffer[len] = 0; // Null-terminate whatever we received and treat like a string
+			ESP_LOGD(TAG, "Received %d bytes from %s:", len, nm->addr_str);
+			ESP_LOGD(TAG, "%s", nm->rx_buffer);
+			return nm->rx_buffer;
+		}
+	}
 }
 
 /**
@@ -111,7 +111,7 @@ char* tcp_receive_data(struct tcp_network_data* nm)
  **/
 void tcp_close_network_manager(struct tcp_network_data* nm)
 {
-    ESP_LOGI(TAG, "%s", "Shutting down socket and restarting...");
-    shutdown(nm->sock, 0);
-    close(nm->sock);
+	ESP_LOGI(TAG, "%s", "Shutting down socket and restarting...");
+	shutdown(nm->sock, 0);
+	close(nm->sock);
 }

--- a/udp_handler.c
+++ b/udp_handler.c
@@ -10,22 +10,22 @@ static const char *TAG = "udp_handler";
  **/
 void network_manager(struct network_data* nm)
 {
-    nm->dest_addr.sin_addr.s_addr = inet_addr(HOST_IP_ADDR);
-    nm->dest_addr.sin_family = AF_INET;
-    nm->dest_addr.sin_port = htons(PORT);
-    nm->addr_family = AF_INET;
-    nm->ip_protocol = IPPROTO_IP;
-    inet_ntoa_r(nm->dest_addr.sin_addr, nm->addr_str, sizeof(nm->addr_str) - 1);
+	nm->dest_addr.sin_addr.s_addr = inet_addr(HOST_IP_ADDR);
+	nm->dest_addr.sin_family = AF_INET;
+	nm->dest_addr.sin_port = htons(PORT);
+	nm->addr_family = AF_INET;
+	nm->ip_protocol = IPPROTO_IP;
+	inet_ntoa_r(nm->dest_addr.sin_addr, nm->addr_str, sizeof(nm->addr_str) - 1);
 
-    nm->sock = socket(nm->addr_family, SOCK_DGRAM, nm->ip_protocol);
-    if (nm->sock < 0)
-    {
-        ESP_LOGE(TAG, "Unable to create socket: errno %d", errno);
-    }
-    else
-    {
-        ESP_LOGI(TAG, "Socket created, connected to %s:%d", HOST_IP_ADDR, PORT);
-    }
+	nm->sock = socket(nm->addr_family, SOCK_DGRAM, nm->ip_protocol);
+	if (nm->sock < 0)
+	{
+		ESP_LOGE(TAG, "Unable to create socket: errno %d", errno);
+	}
+	else
+	{
+		ESP_LOGI(TAG, "Socket created, connected to %s:%d", HOST_IP_ADDR, PORT);
+	}
 }
 
 /**
@@ -37,17 +37,17 @@ void network_manager(struct network_data* nm)
  **/
 int send_data(struct network_data* nm, char* payload)
 {
-    int err = sendto(nm->sock, payload, strlen(payload), 0, (struct sockaddr *)&(nm->dest_addr), sizeof(nm->dest_addr));
-    if (err < 0) 
-    {
-        ESP_LOGE(TAG, "Error occurred during sending: errno %d", errno);
-    }
-    else
-    {
-        ESP_LOGD(TAG, "%s", "Message sent");
-    }
-    
-    return err;
+	int err = sendto(nm->sock, payload, strlen(payload), 0, (struct sockaddr *)&(nm->dest_addr), sizeof(nm->dest_addr));
+	if (err < 0)
+	{
+		ESP_LOGE(TAG, "Error occurred during sending: errno %d", errno);
+	}
+	else
+	{
+		ESP_LOGD(TAG, "%s", "Message sent");
+	}
+
+	return err;
 }
 
 /**
@@ -58,22 +58,22 @@ int send_data(struct network_data* nm, char* payload)
  **/
 char* receive_data(struct network_data* nm)
 {
-    struct sockaddr_in source_addr;
-    socklen_t socklen = sizeof(source_addr);
-    int len = recvfrom(nm->sock, nm->rx_buffer, sizeof(nm->rx_buffer) - 1, 0, (struct sockaddr *)&source_addr, &socklen);
+	struct sockaddr_in source_addr;
+	socklen_t socklen = sizeof(source_addr);
+	int len = recvfrom(nm->sock, nm->rx_buffer, sizeof(nm->rx_buffer) - 1, 0, (struct sockaddr *)&source_addr, &socklen);
 
-    if (len < 0) 
-    {
-        ESP_LOGE(TAG, "recvfrom failed: errno %d", errno);
-        return NULL;
-    }
-    else
-    {
-        nm->rx_buffer[len] = 0; // Null-terminate whatever we received and treat like a string
-        ESP_LOGD(TAG, "Received %d bytes from %s:", len, nm->addr_str);
-        ESP_LOGD(TAG, "%s", nm->rx_buffer);
-        return nm->rx_buffer;
-    }
+	if (len < 0)
+	{
+		ESP_LOGE(TAG, "recvfrom failed: errno %d", errno);
+		return NULL;
+	}
+	else
+	{
+		nm->rx_buffer[len] = 0; // Null-terminate whatever we received and treat like a string
+		ESP_LOGD(TAG, "Received %d bytes from %s:", len, nm->addr_str);
+		ESP_LOGD(TAG, "%s", nm->rx_buffer);
+		return nm->rx_buffer;
+	}
 }
 
 /**
@@ -84,8 +84,8 @@ char* receive_data(struct network_data* nm)
  **/
 void close_network_manager(struct network_data* nm)
 {
-    ESP_LOGI(TAG, "%s", "Shutting down socket");
-    shutdown(nm->sock, 0);
-    close(nm->sock);
-    free(nm);
+	ESP_LOGI(TAG, "%s", "Shutting down socket");
+	shutdown(nm->sock, 0);
+	close(nm->sock);
+	free(nm);
 }

--- a/websocket_handler.c
+++ b/websocket_handler.c
@@ -24,6 +24,7 @@ void websocket_event_handler(void *handler_args, esp_event_base_t base, int32_t 
             break;
 
         case WEBSOCKET_EVENT_DATA:
+        	//Avoid printing logs if it is just a ping/pong frame.
         	if(websocket_op_ping_frame != data->op_code && websocket_op_pong_frame != data->op_code)
         	{
         		ESP_LOGI(TAG, "WEBSOCKET_EVENT_DATA");

--- a/websocket_handler.c
+++ b/websocket_handler.c
@@ -24,9 +24,12 @@ void websocket_event_handler(void *handler_args, esp_event_base_t base, int32_t 
             break;
 
         case WEBSOCKET_EVENT_DATA:
-            ESP_LOGI(TAG, "WEBSOCKET_EVENT_DATA");
-            ESP_LOGI(TAG, "Received opcode=%d", data->op_code);
-            ESP_LOGW(TAG, "Received=%.*s\r\n", data->data_len, (char*)data->data_ptr);
+        	if(websocket_op_ping_frame != data->op_code && websocket_op_pong_frame != data->op_code)
+        	{
+        		ESP_LOGI(TAG, "WEBSOCKET_EVENT_DATA");
+        		ESP_LOGI(TAG, "Received opcode=%d", data->op_code);
+        		ESP_LOGW(TAG, "Received=%.*s\r\n", data->data_len, (char*)data->data_ptr);
+        	}
             break;
         case WEBSOCKET_EVENT_ERROR:
             ESP_LOGI(TAG, "WEBSOCKET_EVENT_ERROR");

--- a/websocket_handler.c
+++ b/websocket_handler.c
@@ -12,31 +12,31 @@ static const char* TAG = "websocket_handler";
  */
 void websocket_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data)
 {
-    esp_websocket_event_data_t *data = (esp_websocket_event_data_t *)event_data;
+	esp_websocket_event_data_t *data = (esp_websocket_event_data_t *)event_data;
 
-    switch (event_id) {
-        case WEBSOCKET_EVENT_CONNECTED:
-            ESP_LOGI(TAG, "WEBSOCKET_EVENT_CONNECTED");
+	switch (event_id) {
+	case WEBSOCKET_EVENT_CONNECTED:
+		ESP_LOGI(TAG, "WEBSOCKET_EVENT_CONNECTED");
 
-            break;
-        case WEBSOCKET_EVENT_DISCONNECTED:
-            ESP_LOGI(TAG, "WEBSOCKET_EVENT_DISCONNECTED");
-            break;
+		break;
+	case WEBSOCKET_EVENT_DISCONNECTED:
+		ESP_LOGI(TAG, "WEBSOCKET_EVENT_DISCONNECTED");
+		break;
 
-        case WEBSOCKET_EVENT_DATA:
-        	  //Avoid printing logs if it is just a ping/pong frame.
-        	  if(websocket_op_ping_frame != data->op_code && websocket_op_pong_frame != data->op_code)
-        	  {
-        		  ESP_LOGI(TAG, "WEBSOCKET_EVENT_DATA");
-        		  ESP_LOGI(TAG, "Received opcode=%d", data->op_code);
-        		  ESP_LOGW(TAG, "Received=%.*s\r\n", data->data_len, (char*)data->data_ptr);
-        	  }
-            break;
-        
-        case WEBSOCKET_EVENT_ERROR:
-            ESP_LOGW(TAG, "WEBSOCKET_EVENT_ERROR");
-            break;
-    }
+	case WEBSOCKET_EVENT_DATA:
+		//Avoid printing logs if it is just a ping/pong frame.
+		if(websocket_op_ping_frame != data->op_code && websocket_op_pong_frame != data->op_code)
+		{
+			ESP_LOGI(TAG, "WEBSOCKET_EVENT_DATA");
+			ESP_LOGI(TAG, "Received opcode=%d", data->op_code);
+			ESP_LOGW(TAG, "Received=%.*s\r\n", data->data_len, (char*)data->data_ptr);
+		}
+		break;
+
+	case WEBSOCKET_EVENT_ERROR:
+		ESP_LOGW(TAG, "WEBSOCKET_EVENT_ERROR");
+		break;
+	}
 }
 
 /**
@@ -46,20 +46,20 @@ void websocket_event_handler(void *handler_args, esp_event_base_t base, int32_t 
  */
 esp_websocket_client_handle_t websocket_network_manager()
 {
-    ESP_LOGI(TAG, "Connecting to %s...", WEBSOCKET_HOST_URI);
+	ESP_LOGI(TAG, "Connecting to %s...", WEBSOCKET_HOST_URI);
 
-    esp_websocket_client_handle_t network_handle;
+	esp_websocket_client_handle_t network_handle;
 
-    const esp_websocket_client_config_t websocket_cfg = {
-        .uri = WEBSOCKET_HOST_URI,
-    };
+	const esp_websocket_client_config_t websocket_cfg = {
+			.uri = WEBSOCKET_HOST_URI,
+	};
 
-    network_handle = esp_websocket_client_init(&websocket_cfg);
-    esp_websocket_register_events(network_handle, WEBSOCKET_EVENT_ANY, websocket_event_handler, (void *)network_handle);
+	network_handle = esp_websocket_client_init(&websocket_cfg);
+	esp_websocket_register_events(network_handle, WEBSOCKET_EVENT_ANY, websocket_event_handler, (void *)network_handle);
 
-    esp_websocket_client_start(network_handle);
+	esp_websocket_client_start(network_handle);
 
-    return network_handle;
+	return network_handle;
 }
 
 /**
@@ -72,23 +72,23 @@ esp_websocket_client_handle_t websocket_network_manager()
 int websocket_send_data(esp_websocket_client_handle_t network_handle, char* payload)
 {
 
-    if (esp_websocket_client_is_connected(network_handle)) 
-    {
-        int err = esp_websocket_client_send(network_handle, payload, strlen(payload), portMAX_DELAY);
-        
-        if (err < 0)
-        {
-            ESP_LOGE(TAG, "Error occured during sending: errno %d", errno);
-        }
-        else
-        {
-            ESP_LOGD(TAG, "%s", "Message sent");
-        }
-        
-        return err;
-    }
+	if (esp_websocket_client_is_connected(network_handle))
+	{
+		int err = esp_websocket_client_send(network_handle, payload, strlen(payload), portMAX_DELAY);
 
-    return -1;
+		if (err < 0)
+		{
+			ESP_LOGE(TAG, "Error occured during sending: errno %d", errno);
+		}
+		else
+		{
+			ESP_LOGD(TAG, "%s", "Message sent");
+		}
+
+		return err;
+	}
+
+	return -1;
 }
 
 /**
@@ -98,7 +98,7 @@ int websocket_send_data(esp_websocket_client_handle_t network_handle, char* payl
  */
 void websocket_close_network_manager(esp_websocket_client_handle_t network_handle)
 {
-    esp_websocket_client_stop(network_handle);
-    esp_websocket_client_destroy(network_handle);
-    ESP_LOGI(TAG, "Websocket Stopped");
+	esp_websocket_client_stop(network_handle);
+	esp_websocket_client_destroy(network_handle);
+	ESP_LOGI(TAG, "Websocket Stopped");
 }

--- a/websocket_handler.c
+++ b/websocket_handler.c
@@ -13,10 +13,10 @@ static const char* TAG = "websocket_handler";
 void websocket_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data)
 {
     esp_websocket_event_data_t *data = (esp_websocket_event_data_t *)event_data;
+
     switch (event_id) {
         case WEBSOCKET_EVENT_CONNECTED:
             ESP_LOGI(TAG, "WEBSOCKET_EVENT_CONNECTED");
-
 
             break;
         case WEBSOCKET_EVENT_DISCONNECTED:
@@ -70,7 +70,6 @@ esp_websocket_client_handle_t websocket_network_manager()
  */
 int websocket_send_data(esp_websocket_client_handle_t network_handle, char* payload)
 {
-    while(!esp_websocket_client_is_connected(network_handle));
 
     if (esp_websocket_client_is_connected(network_handle)) 
     {
@@ -87,12 +86,8 @@ int websocket_send_data(esp_websocket_client_handle_t network_handle, char* payl
         
         return err;
     }
-    else
-    {
-        ESP_LOGE(TAG, "%s", "Client not connected");
 
-        return -1;
-    }
+    return -1;
 }
 
 /**

--- a/wifi_logger.c
+++ b/wifi_logger.c
@@ -7,33 +7,33 @@ static QueueHandle_t wifi_logger_queue;
  * @brief Initialises message queue
  * 
  * @return esp_err_t ESP_OK - if queue init sucessfully, ESP_FAIL - if queue init failed
-**/
+ **/
 esp_err_t init_queue(void)
 {
-    wifi_logger_queue = xQueueCreate(MESSAGE_QUEUE_SIZE, sizeof(char*));
-    
-    if (wifi_logger_queue == NULL)
-    {
-        ESP_LOGE(tag_wifi_logger, "%s", "Queue creation failed");
-        return ESP_FAIL;
-    }
-    else
-    {
-        ESP_LOGI(tag_wifi_logger, "%s", "Queue created");
-        return ESP_OK;
-    }
+	wifi_logger_queue = xQueueCreate(MESSAGE_QUEUE_SIZE, sizeof(char*));
+
+	if (wifi_logger_queue == NULL)
+	{
+		ESP_LOGE(tag_wifi_logger, "%s", "Queue creation failed");
+		return ESP_FAIL;
+	}
+	else
+	{
+		ESP_LOGI(tag_wifi_logger, "%s", "Queue created");
+		return ESP_OK;
+	}
 }
 
 /**
  * @brief Initialises and connects to wifi
-**/
+ **/
 void init_wifi(void)
 {
-    ESP_ERROR_CHECK(nvs_flash_init());
-    ESP_ERROR_CHECK(esp_netif_init());
-    ESP_ERROR_CHECK(esp_event_loop_create_default());
-    
-    ESP_ERROR_CHECK(example_connect());
+	ESP_ERROR_CHECK(nvs_flash_init());
+	ESP_ERROR_CHECK(esp_netif_init());
+	ESP_ERROR_CHECK(esp_event_loop_create_default());
+
+	ESP_ERROR_CHECK(example_connect());
 }
 
 /**
@@ -41,62 +41,62 @@ void init_wifi(void)
  * 
  * @param log_message log message to be sent to the queue
  * @return esp_err_t ESP_OK - if queue init sucessfully, ESP_FAIL - if queue init failed
-**/
+ **/
 esp_err_t send_to_queue(char* log_message)
 {
-    BaseType_t qerror = xQueueSendToBack(wifi_logger_queue, (void*)&log_message, (TickType_t) 0/portTICK_PERIOD_MS);
-    
-    if(qerror == pdPASS)
-    {
-        ESP_LOGD(tag_wifi_logger, "%s", "Data sent to Queue");
-        return ESP_OK;
-    }
-    else if(qerror == errQUEUE_FULL)
-    {
-        ESP_LOGE(tag_wifi_logger, "%s", "Data not sent to Queue, Queue full");
-        return ESP_FAIL;
-    }
-    else
-    {
-        ESP_LOGE(tag_wifi_logger, "%s", "Unknown error");
-        return ESP_FAIL;
-    }
+	BaseType_t qerror = xQueueSendToBack(wifi_logger_queue, (void*)&log_message, (TickType_t) 0/portTICK_PERIOD_MS);
+
+	if(qerror == pdPASS)
+	{
+		ESP_LOGD(tag_wifi_logger, "%s", "Data sent to Queue");
+		return ESP_OK;
+	}
+	else if(qerror == errQUEUE_FULL)
+	{
+		ESP_LOGE(tag_wifi_logger, "%s", "Data not sent to Queue, Queue full");
+		return ESP_FAIL;
+	}
+	else
+	{
+		ESP_LOGE(tag_wifi_logger, "%s", "Unknown error");
+		return ESP_FAIL;
+	}
 }
 
 /**
  * @brief Receive data from queue. Timeout is set to portMAX_DELAY, which is around 50 days (confirm from esp32 specs)
  * 
  * @return char* - returns log message received from the queue, returns NULL if error
-**/
+ **/
 char* receive_from_queue(void)
 {
-    char* data;
-    // ************************* IMPORTANT *******************************************************************
-    // Timeout period is set to portMAX_DELAY, so if it doesnot receive a log message for ~50 days, config assert will fail and program will crash
-    //
-    BaseType_t qerror = xQueueReceive(wifi_logger_queue, &data, (TickType_t) portMAX_DELAY);
-    configASSERT(qerror);
-    //
-    // *******************************************************************************************************
-    
-    if(qerror == pdPASS)
-    {
-        ESP_LOGD(tag_wifi_logger, "%s", "Data received from Queue");
-    }
-    else if(qerror == pdFALSE)
-    {
-        ESP_LOGW(tag_wifi_logger, "%s", "Data not received from Queue");
-        data = NULL;
-    }
-    else
-    {
-        free((void*)data);
-        
-        ESP_LOGE(tag_wifi_logger, "%s", "Unknown error");
-        data = NULL;
-    }
+	char* data;
+	// ************************* IMPORTANT *******************************************************************
+	// Timeout period is set to portMAX_DELAY, so if it doesnot receive a log message for ~50 days, config assert will fail and program will crash
+	//
+	BaseType_t qerror = xQueueReceive(wifi_logger_queue, &data, (TickType_t) portMAX_DELAY);
+	configASSERT(qerror);
+	//
+	// *******************************************************************************************************
 
-    return data;
+	if(qerror == pdPASS)
+	{
+		ESP_LOGD(tag_wifi_logger, "%s", "Data received from Queue");
+	}
+	else if(qerror == pdFALSE)
+	{
+		ESP_LOGW(tag_wifi_logger, "%s", "Data not received from Queue");
+		data = NULL;
+	}
+	else
+	{
+		free((void*)data);
+
+		ESP_LOGE(tag_wifi_logger, "%s", "Unknown error");
+		data = NULL;
+	}
+
+	return data;
 }
 
 /**
@@ -110,57 +110,57 @@ char* receive_from_queue(void)
  */
 void generate_log_message(esp_log_level_t level, const char *TAG, int line, const char *func, const char *fmt, ...)
 {
-    char log_print_buffer[BUFFER_SIZE];
+	char log_print_buffer[BUFFER_SIZE];
 
-    memset(log_print_buffer, '\0', BUFFER_SIZE);
-    snprintf(log_print_buffer, BUFFER_SIZE, "%s (%s:%d) ", TAG, func, line);
-    va_list args;
-    va_start(args, fmt);
+	memset(log_print_buffer, '\0', BUFFER_SIZE);
+	snprintf(log_print_buffer, BUFFER_SIZE, "%s (%s:%d) ", TAG, func, line);
+	va_list args;
+	va_start(args, fmt);
 
-    int len = strlen(log_print_buffer);
+	int len = strlen(log_print_buffer);
 
-    if (BUFFER_SIZE - len > 1)
-    {
-        vsnprintf(&log_print_buffer[len], (BUFFER_SIZE - len), fmt, args);
-    }
-    else
-    {
-        memset(log_print_buffer, '\0', BUFFER_SIZE);
-        sprintf(log_print_buffer, "%s", "Buffer overflowed, increase buffer size");
-    }
-    va_end(args);
-    
-    uint log_level_opt = 2;
+	if (BUFFER_SIZE - len > 1)
+	{
+		vsnprintf(&log_print_buffer[len], (BUFFER_SIZE - len), fmt, args);
+	}
+	else
+	{
+		memset(log_print_buffer, '\0', BUFFER_SIZE);
+		sprintf(log_print_buffer, "%s", "Buffer overflowed, increase buffer size");
+	}
+	va_end(args);
 
-    switch (level)
-    {
-    case ESP_LOG_ERROR:
-        log_level_opt = 0;
-        break;
-    case ESP_LOG_WARN:
-        log_level_opt = 1;
-        break;
-    case ESP_LOG_INFO:
-        log_level_opt = 2;
-        break;
-    case ESP_LOG_DEBUG:
-        log_level_opt = 3;
-        break;
-    case ESP_LOG_VERBOSE:
-        log_level_opt = 4;
-        break;
-    default:
-        log_level_opt = 2;
-        break;
-    }
+	uint log_level_opt = 2;
 
-    // ************************* IMPORTANT *******************************************************************
-    // I am mallocing a char* inside generate_log_timestamp() function situated inside util.cpp, log_print_buffer is not being pushed to queue
-    // The function returns the malloc'd char* and is passed to the queue
-    //
-    send_to_queue(generate_log_message_timestamp(log_level_opt, esp_log_timestamp(), log_print_buffer));
-    //
-    //********************************************************************************************************
+	switch (level)
+	{
+	case ESP_LOG_ERROR:
+		log_level_opt = 0;
+		break;
+	case ESP_LOG_WARN:
+		log_level_opt = 1;
+		break;
+	case ESP_LOG_INFO:
+		log_level_opt = 2;
+		break;
+	case ESP_LOG_DEBUG:
+		log_level_opt = 3;
+		break;
+	case ESP_LOG_VERBOSE:
+		log_level_opt = 4;
+		break;
+	default:
+		log_level_opt = 2;
+		break;
+	}
+
+	// ************************* IMPORTANT *******************************************************************
+	// I am mallocing a char* inside generate_log_timestamp() function situated inside util.cpp, log_print_buffer is not being pushed to queue
+	// The function returns the malloc'd char* and is passed to the queue
+	//
+	send_to_queue(generate_log_message_timestamp(log_level_opt, esp_log_timestamp(), log_print_buffer));
+	//
+	//********************************************************************************************************
 }
 
 /**
@@ -172,12 +172,12 @@ void generate_log_message(esp_log_level_t level, const char *TAG, int line, cons
  */
 int system_log_message_route(const char* fmt, va_list tag)
 {
-    char *log_print_buffer = (char*) malloc(sizeof(char) * BUFFER_SIZE);
-    vsprintf(log_print_buffer, fmt, tag);
+	char *log_print_buffer = (char*) malloc(sizeof(char) * BUFFER_SIZE);
+	vsprintf(log_print_buffer, fmt, tag);
 
-    send_to_queue(log_print_buffer);
+	send_to_queue(log_print_buffer);
 
-    return vprintf(fmt, tag);
+	return vprintf(fmt, tag);
 }
 
 /**
@@ -186,15 +186,15 @@ int system_log_message_route(const char* fmt, va_list tag)
  */
 void start_wifi_logger(void)
 {
-    init_wifi();
-    ESP_ERROR_CHECK(init_queue());
+	init_wifi();
+	ESP_ERROR_CHECK(init_queue());
 
-    #ifdef CONFIG_ROUTE_ESP_IDF_API_LOGS_TO_WIFI
-    esp_log_set_vprintf(system_log_message_route);
-    #endif
+#ifdef CONFIG_ROUTE_ESP_IDF_API_LOGS_TO_WIFI
+	esp_log_set_vprintf(system_log_message_route);
+#endif
 
-    xTaskCreatePinnedToCore(&wifi_logger, "wifi_logger", 4096, NULL, 2, NULL, 1);
-    ESP_LOGI(tag_wifi_logger, "WiFi logger initialised");
+	xTaskCreatePinnedToCore(&wifi_logger, "wifi_logger", 4096, NULL, 2, NULL, 1);
+	ESP_LOGI(tag_wifi_logger, "WiFi logger initialised");
 }
 
 /*
@@ -212,13 +212,16 @@ bool is_connected(void* handle_t)
 #endif
 #ifdef CONFIG_TRANSPORT_PROTOCOL_TCP
 	/* Technically ENOTCONN indicates socket is not connected but I think there is a bug
-	* Check out https://github.com/espressif/esp-idf/issues/6092 to follow the issue ticket raised
-	* Till then keeping the following check instead of just 0 == errno
-	**/
+	 * Check out https://github.com/espressif/esp-idf/issues/6092 to follow the issue ticket raised
+	 * Till then keeping the following check instead of just 0 == errno
+	 **/
 	if (0 == errno || ENOTCONN == errno)
 	{
 		ret = true;
 	}
+#endif
+#ifdef CONFIG_TRANSPORT_PROTOCOL_UDP
+	ret = true;
 #endif
 
 	return ret;
@@ -231,29 +234,29 @@ bool is_connected(void* handle_t)
 #ifdef CONFIG_TRANSPORT_PROTOCOL_UDP
 void wifi_logger()
 {
-    struct network_data* handle = malloc(sizeof(struct network_data));
-    network_manager(handle);
+	struct network_data* handle = malloc(sizeof(struct network_data));
+	network_manager(handle);
 
-    while (true)
-    {
-        char* log_message = receive_from_queue();
- 
-        if (log_message != NULL)
-        {
-            int len = send_data(handle, log_message);
-            ESP_LOGD(tag_wifi_logger, "%d %s", len, "bytes of data sent");
-            
-            free((void*)log_message);
-        }
-        else
-        {
-            log_message = "Unknown error - receiving log message";
-            int len = send_data(handle, log_message);
-            ESP_LOGE(tag_wifi_logger, "%d %s", len, "Unknown error");
-        }
-    }
+	while (true)
+	{
+		char* log_message = receive_from_queue();
 
-    close_network_manager(handle);
+		if (log_message != NULL)
+		{
+			int len = send_data(handle, log_message);
+			ESP_LOGD(tag_wifi_logger, "%d %s", len, "bytes of data sent");
+
+			free((void*)log_message);
+		}
+		else
+		{
+			log_message = "Unknown error - receiving log message";
+			int len = send_data(handle, log_message);
+			ESP_LOGE(tag_wifi_logger, "%d %s", len, "Unknown error");
+		}
+	}
+
+	close_network_manager(handle);
 }
 #endif
 
@@ -289,7 +292,7 @@ void wifi_logger()
 					{
 						/* Trying to push it back to queue if sending fails, but might lose some logs if frequency is high
 						 * Might see garbage at first when reconnected.
-						*/
+						 */
 						xQueueSendToFront(wifi_logger_queue, (void*)log_message, (TickType_t) portMAX_DELAY);
 						break;
 					}
@@ -317,12 +320,12 @@ void wifi_logger()
 #ifdef CONFIG_TRANSPORT_PROTOCOL_WEBSOCKET
 void wifi_logger()
 {
-    esp_websocket_client_handle_t handle = websocket_network_manager();
+	esp_websocket_client_handle_t handle = websocket_network_manager();
 
-    while (true)
-    {
-    	if(is_connected(handle))
-    	{
+	while (true)
+	{
+		if(is_connected(handle))
+		{
 			char* log_message = receive_from_queue();
 
 			if (log_message != NULL)
@@ -342,15 +345,15 @@ void wifi_logger()
 				int len = websocket_send_data(handle, log_message);
 				ESP_LOGE(tag_wifi_logger, "%d %s", len, "Unknown error");
 			}
-    	}
-    	else
-    	{
-    		//Checkout following link to understand why we need this delay if want watchdog running.
-    		//https://github.com/espressif/esp-idf/issues/1646#issuecomment-367507724
-    		vTaskDelay(10 / portTICK_PERIOD_MS);
-    	}
-    }
+		}
+		else
+		{
+			//Checkout following link to understand why we need this delay if want watchdog running.
+			//https://github.com/espressif/esp-idf/issues/1646#issuecomment-367507724
+			vTaskDelay(10 / portTICK_PERIOD_MS);
+		}
+	}
 
-    websocket_close_network_manager(handle);
+	websocket_close_network_manager(handle);
 }
 #endif


### PR DESCRIPTION
Features added 
1) Robust websocket connection, logs preserved when server is down and sent in chronologically once it is up. 
2) Even when client dies and comes up again, it will be able to connect to server without any issues. 
3) TCP-Client is now better, can reconnect to server if it goes down and will send logs later in chronological order with least data-loss. Tried at 100Hz data logging. 
4) removed unnecessary logs to avoid over-flowing.