### PR TITLE
Two small fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,4 +10,4 @@ endif()
 
 idf_component_register(SRCS "${srcs}"
                        INCLUDE_DIRS "include"
-                       REQUIRES protocol_examples_common nvs_flash esp_websocket_client)
+                       REQUIRES  esp_wifi protocol_examples_common nvs_flash esp_websocket_client )

--- a/include/utils.h
+++ b/include/utils.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-char* generate_log_message_timestamp(uint log_level, uint32_t timestamp, char* log_message);
+char* generate_log_message_timestamp(uint8_t log_level, uint32_t timestamp, char* log_message);
 
 #ifdef __cplusplus
 }

--- a/utils.cpp
+++ b/utils.cpp
@@ -11,7 +11,7 @@ const char log_level_color[5][7] = {"\e[31m", "\e[33m", "\e[32m", "\e[39m", "\e[
  * @param log_message log message to be sent through wifi
  * @return char* final log message with timestamp
  */
-char* generate_log_message_timestamp(uint log_level, uint32_t timestamp, char* log_message)
+char* generate_log_message_timestamp(uint8_t log_level, uint32_t timestamp, char* log_message)
 {
     log_level = log_level%5;
 


### PR DESCRIPTION
1. Add esp_wifi dependency into CMakeLists.txt to prevent compilation error
`ninja: build stopped: subcommand failed.
Compilation failed because tcp_handler.h (in "wifi_logger" component) includes esp_wifi.h, provided by esp_wifi component(s).
However, esp_wifi component(s) is not in the requirements list of "wifi_logger".
To fix this, add esp_wifi to REQUIRES list of idf_component_register call in /work/espidf/pump/components/wifi_logger/CMakeLists.txt.`
2. Replace unknown type uint, because I have got error:
`/work/espidf/pump/components/wifi_logger/include/utils.h:10:38: error: 'uint' was not declared in this scope; did you mean 'int'?
   10 | char* generate_log_message_timestamp(uint log_level, uint32_t timestamp, char* log_message);`